### PR TITLE
Always increment session in send

### DIFF
--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -796,18 +796,16 @@ void application_impl::send(std::shared_ptr<message> _message, bool _flush) {
             << "type=" << std::hex << static_cast<std::uint32_t>(_message->get_message_type())
             << " thread=" << std::hex << std::this_thread::get_id();
     }
+
+    // in case of requests set the request-id (client-id|session-id)
+    if (is_request) {
+        _message->set_client(client_);
+        _message->set_session(session_);
+        update_session();
+    }
+
     if (routing_) {
-        // in case of requests set the request-id (client-id|session-id)
-        if (is_request) {
-            _message->set_client(client_);
-            _message->set_session(session_);
-        }
-        // in case of successful sending, increment the session-id
-        if (routing_->send(client_, _message, _flush)) {
-            if (is_request) {
-                update_session();
-            }
-        }
+        routing_->send(client_, _message, _flush);
     }
 }
 


### PR DESCRIPTION
Send sometimes silently fails and in those cases the session is not
incremented. This behavior makes it impossible for the client to do
book keeping. Consider the case where a client sends two requests on a
newly created application. The first request fails and the second
succeeds, but from the client's perspective both have succeeded,
because send can't fail. The problem is that both sends have returned
the same request id (client and 1), when the response for request two
comes there is no way for the client to know if it is for the first or
second request.