### PR TITLE
cmake: Modernize exported CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ endif()
 
 add_library(vsomeip SHARED ${vsomeip_SRC} ${vsomeip_e2e_SRC})
 set_target_properties (vsomeip PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
+target_include_directories(vsomeip INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
 # PRIVATE means the listed libraries won't be included in the "link interface",
 # meaning the exported vsomeipTargets.cmake targets won't try to link against
 # them (which shouldn't be required). ${Boost_LIBRARIES} includes absolute
@@ -284,17 +288,7 @@ export (TARGETS vsomeip FILE "${PROJECT_BINARY_DIR}/vsomeipTargets.cmake")
 export (PACKAGE vsomeip)
 
 # Create the vsomeipConfig.cmake and vsomeipConfigVersion files
-file (RELATIVE_PATH REL_INCLUDE_DIR "${ABSOLUTE_INSTALL_CMAKE_DIR}" "${ABSOLUTE_INSTALL_INCLUDE_DIR}")
-
-# ... for the build tree
-set (CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/interface" "${PROJECT_BINARY_DIR}")
 configure_file (vsomeipConfig.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake" @ONLY)
-
-# ... for the install tree
-set (CONF_INCLUDE_DIRS "\${VSOMEIP_CMAKE_DIR}/${REL_INCLUDE_DIR}")
-configure_file (vsomeipConfig.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vsomeipConfig.cmake" @ONLY)
-
-# ... for both
 configure_file (vsomeipConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake" @ONLY)
 
 # confugure internal.hpp for correct version number
@@ -306,7 +300,7 @@ configure_file (
 # Install the vsomeipConfig.cmake and vsomeipConfigVersion.cmake
 install (
     FILES
-    "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vsomeipConfig.cmake"
+    "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake"
     "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake"
     DESTINATION "${INSTALL_CMAKE_DIR}"
     COMPONENT dev

--- a/vsomeipConfig.cmake.in
+++ b/vsomeipConfig.cmake.in
@@ -1,10 +1,14 @@
 # Config file for the vSomeIP package, defines the following variables:
-#   VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP
-#   VSOMEIP_LIBRARIES    - libraries to link against
+# Exports the following targets:
+#   vsomeip - CMake target for vSomeIP
+# Additionally, the following variables are defined:
+#   VSOMEIP_LIBRARIES - list of libraries to link against, contains only
+#                       "vsomeip"
 
 # Compute paths
 get_filename_component (VSOMEIP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set (VSOMEIP_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+# Legacy variable, no longer used but kept for compatibility
+set(VSOMEIP_INCLUDE_DIRS "")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 if (NOT TARGET vsomeip AND NOT vsomeip_BINARY_DIR)


### PR DESCRIPTION
The CMake configuration files exported by vSomeIP require users to add the `${VSOMEIP_INCLUDE_DIRS}` variable to their project's include directories. This was done to support building against a build tree of vSomeIP by generating two different `vsomeipConfig.cmake` files that
defined this variable with different values.

This is now no longer necessary since CMake supports the `$<BUILD_INTERFACE>` and `$<INSTALL_INTERFACE>` generator expressions which can be used to make the same distinction with only a single `vsomeipConfig.cmake` file.

This also allows users of vSomeIP to get the required include directories into their build by using
```cmake
target_link_libraries(${target} vsomeip)
```
since the exported vSomeIP CMake target now has the required include directories set as a property. This is much more idiomatic for users of CMake and is thus preferred.

Additionally, this enables downstream projects that build CommonAPI-SomeIP interface libraries to no longer care about what the vSomeIP include directories are, which simplifies writing CMake config
files for them.

I've locally compiled vSomeIP, CommonAPI, CommonAPI-SomeIP and a test project using CommonAPI-SomeIP to test this.