### PR TITLE
Changed -fstack-protector-strong to -ftsack-protector-all and changed a method scope.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(EXPORTSYMBOLS "-Wl,-export-dynamic -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exportmap.gcc")
     set(NO_DEPRECATED "")
     set(OPTIMIZE "")
-    set(OS_CXX_FLAGS "-D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -fPIE -pie -Wl,-z,relro,-z,now")
+    set(OS_CXX_FLAGS "-D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-all -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -fPIE -pie -Wl,-z,relro,-z,now")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")

--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -124,6 +124,9 @@ public:
 
     std::set<client_t> find_local_clients(service_t _service, instance_t _instance);
 
+    void erase_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
+            eventgroup_t _eventgroup, event_t _event);
+
 protected:
     std::shared_ptr<serviceinfo> find_service(service_t _service, instance_t _instance) const;
     std::shared_ptr<serviceinfo> create_service_info(service_t _service,
@@ -215,8 +218,6 @@ protected:
     subscription_state_e get_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
             eventgroup_t _eventgroup, event_t _event);
 
-    void erase_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
-            eventgroup_t _eventgroup, event_t _event);
 
 private:
     std::shared_ptr<endpoint> create_local_unlocked(client_t _client);


### PR DESCRIPTION
 Withouth this change gcc 4.8 complains that -fstack-protector-strong is not supported. Hence changed the CMakeLists.txt to -fstack-protector-all

Changed the scope of a protected method to public to address compilation error