### PR TITLE
Fix for 'make doc'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ else()
                                -a version=${VSOMEIP_VERSION}
                                -b html
                                -o documentation/vsomeipUserGuide.html
-                               ${PROJECT_BINARY_DIR}/../documentation/vsomeipUserGuide)
+                               ${PROJECT_SOURCE_DIR}/documentation/vsomeipUserGuide)
 endif()
 
 ##############################################################################


### PR DESCRIPTION
Documentation generation fails if 'default' build folder structure is not used.