### PR TITLE
read major, minor, tll service from json for static routing

### DIFF
--- a/implementation/configuration/include/configuration.hpp
+++ b/implementation/configuration/include/configuration.hpp
@@ -76,6 +76,12 @@ public:
             uint16_t _port) const = 0;
     virtual uint16_t get_unreliable_port(service_t _service,
             instance_t _instance) const = 0;
+    virtual major_version_t get_major_version(service_t _service,
+            instance_t _instance) const = 0;
+    virtual minor_version_t get_minor_version(service_t _service,
+            instance_t _instance) const = 0;
+    virtual ttl_t get_ttl(service_t _service,
+            instance_t _instance) const = 0;
 
     virtual bool is_someip(service_t _service, instance_t _instance) const = 0;
 

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -88,6 +88,12 @@ public:
     VSOMEIP_EXPORT bool has_enabled_magic_cookies(std::string _address, uint16_t _port) const;
     VSOMEIP_EXPORT uint16_t get_unreliable_port(service_t _service,
             instance_t _instance) const;
+    VSOMEIP_EXPORT major_version_t get_major_version(service_t _service,
+            instance_t _instance) const;
+    VSOMEIP_EXPORT minor_version_t get_minor_version(service_t _service,
+            instance_t _instance) const;    
+    VSOMEIP_EXPORT ttl_t get_ttl(service_t _service,
+            instance_t _instance) const;
 
     VSOMEIP_EXPORT bool is_someip(service_t _service, instance_t _instance) const;
 

--- a/implementation/configuration/include/service.hpp
+++ b/implementation/configuration/include/service.hpp
@@ -24,6 +24,9 @@ struct service {
 
     uint16_t reliable_;
     uint16_t unreliable_;
+    major_version_t major_;
+    minor_version_t minor_;
+    ttl_t ttl_;
 
     std::string multicast_address_;
     uint16_t multicast_port_;

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -1345,6 +1345,9 @@ void configuration_impl::load_service(
         its_service->multicast_address_ = "";
         its_service->multicast_port_ = ILLEGAL_PORT;
         its_service->protocol_ = "someip";
+        its_service->major_ = DEFAULT_MAJOR;
+        its_service->minor_ = DEFAULT_MINOR;
+        its_service->ttl_ = DEFAULT_TTL;
 
         for (auto i = _tree.begin(); i != _tree.end(); ++i) {
             std::string its_key(i->first);
@@ -1405,6 +1408,14 @@ void configuration_impl::load_service(
                     its_converter >> its_service->service_;
                 } else if (its_key == "instance") {
                     its_converter >> its_service->instance_;
+                } else if (its_key == "major") {
+                    unsigned temp;
+                    its_converter >> temp;
+                    its_service->major_ = static_cast<major_version_t>(temp);
+                } else if (its_key == "minor") {
+                    its_converter >> its_service->minor_;
+                } else if (its_key == "ttl") {
+                    its_converter >> its_service->ttl_;
                 }
             }
         }
@@ -2663,6 +2674,40 @@ uint16_t configuration_impl::get_unreliable_port(service_t _service,
 
     return its_unreliable;
 }
+
+major_version_t configuration_impl::get_major_version(service_t _service, 
+        instance_t _instance) const {
+    std::lock_guard<std::mutex> its_lock(services_mutex_);
+    major_version_t its_major = DEFAULT_MAJOR;
+    auto its_service = find_service_unlocked(_service, _instance);
+    if (its_service)
+        its_major = its_service->major_;
+
+    return its_major;
+}  
+
+minor_version_t configuration_impl::get_minor_version(service_t _service, 
+        instance_t _instance) const {
+    std::lock_guard<std::mutex> its_lock(services_mutex_);
+    minor_version_t its_minor = DEFAULT_MINOR;
+    auto its_service = find_service_unlocked(_service, _instance);
+    if (its_service)
+        its_minor = its_service->minor_;
+
+    return its_minor;
+}  
+
+ttl_t configuration_impl::get_ttl(service_t _service, 
+        instance_t _instance) const {
+    std::lock_guard<std::mutex> its_lock(services_mutex_);
+    ttl_t its_ttl = DEFAULT_TTL;
+    auto its_service = find_service_unlocked(_service, _instance);
+    if (its_service)
+        its_ttl = its_service->ttl_;
+
+    return its_ttl;
+}  
+
 
 bool configuration_impl::is_someip(service_t _service,
         instance_t _instance) const {

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -2853,12 +2853,19 @@ void routing_manager_impl::init_routing_info() {
             = configuration_->get_reliable_port(i.first, i.second);
         uint16_t its_unreliable_port
             = configuration_->get_unreliable_port(i.first, i.second);
+        major_version_t its_major 
+            = configuration_->get_major_version(i.first, i.second);
+        minor_version_t its_minor
+            = configuration_->get_minor_version(i.first, i.second);
+        ttl_t its_ttl
+            = configuration_->get_ttl(i.first, i.second);
 
         if (its_reliable_port != ILLEGAL_PORT
                 || its_unreliable_port != ILLEGAL_PORT) {
 
+            VSOMEIP_INFO << "Add static remote service [" << std::hex << i.first << "." << i.second << std::dec << ":" <<  +its_major  << "." << its_minor << "]";
             add_routing_info(i.first, i.second,
-                    DEFAULT_MAJOR, DEFAULT_MINOR, DEFAULT_TTL,
+                    its_major, its_minor, its_ttl,
                     its_address, its_reliable_port,
                     its_address, its_unreliable_port);
 


### PR DESCRIPTION
When Service discovery is disabled, vsomeip is using default
major, minor and ttl value. In case service requested is not
version 0.0, vsomeip doesn't route it.
This patch adds possibility to provide major, minor and ttl
values for a static routed service in the vsomeip configuration
file.

Signed-off-by: Jean-Patrice Laude <jean-patrice.laude@renault.com>