### PR TITLE
bugfix: calling dlerror before dlsym to clear possible previous error.

### DIFF
--- a/implementation/plugin/src/plugin_manager_impl.cpp
+++ b/implementation/plugin/src/plugin_manager_impl.cpp
@@ -200,6 +200,7 @@ void * plugin_manager_impl::load_symbol(void * _handle,
     }
 #else
     if (0 != _handle) {
+        dlerror(); // dlerror shall be called before dlsym to clear possible previous error
         its_symbol = dlsym(_handle, _symbol.c_str());
         const char *dlsym_error = dlerror();
         if (dlsym_error) {


### PR DESCRIPTION
bugfix: calling dlerror before dlsym to clear possible previous error.

When there were errors with dlopen/dlsym earlier in the process,
even not related to vsomeip, this makes load_symbol to fail, although
plugin .so is there and the required symbol is available.