### PR TITLE
Fix boost helper 1.70

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -36,7 +36,8 @@ cc_defaults {
         "-Wno-sign-compare",
         "-Wno-format",
         "-Wno-header-guard",
-        "-Wno-overloaded-virtual"
+        "-Wno-overloaded-virtual",
+        "-Wno-implicit-fallthrough"
     ]
 }
 
@@ -95,7 +96,8 @@ cc_library_shared {
     shared_libs: [
         "libvsomeip",
         "libboost_log",
-        "libboost_filesystem"
+        "libboost_filesystem",
+        "libboost_system"
     ]
 }
 
@@ -141,6 +143,7 @@ cc_library_shared {
 
     shared_libs: [
         "libvsomeip",
-        "libboost_log"
+        "libboost_log",
+        "libboost_system"
     ]
 }

--- a/Android.bp
+++ b/Android.bp
@@ -43,7 +43,7 @@ cc_defaults {
 
 cc_library_shared {
     name: "libvsomeip",
-    vendor: true,
+    vendor_available: true,
 
     srcs: libvsomeip_srcs,
 
@@ -78,7 +78,7 @@ cc_library_shared {
 
 cc_library_shared {
     name: "libvsomeip_cfg",
-    vendor: true,
+    vendor_available: true,
 
     srcs: libvsomeip_cfg_srcs,
 
@@ -103,7 +103,7 @@ cc_library_shared {
 
 cc_library_shared {
     name: "libvsomeip_e2e",
-    vendor: true,
+    vendor_available: true,
 
     srcs: libvsomeip_e2e_srcs,
 
@@ -126,7 +126,7 @@ cc_library_shared {
 
 cc_library_shared {
     name: "libvsomeip_sd",
-    vendor: true,
+    vendor_available: true,
 
     srcs: libvsomeip_sd_srcs,
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,8 @@ add_subdirectory( tools )
 # build examples
 add_custom_target( examples )
 add_subdirectory( examples EXCLUDE_FROM_ALL )
+add_custom_target( hello_world )
+add_subdirectory( examples/hello_world  EXCLUDE_FROM_ALL )
 
 ##############################################################################
 # Test section

--- a/examples/hello_world/Android.bp
+++ b/examples/hello_world/Android.bp
@@ -1,0 +1,40 @@
+cc_defaults {
+    name: "vsomeip_hello_world_defaults",
+    vendor: true,
+
+    cppflags: [
+        "-std=c++11",
+        "-Wno-unused-parameter",
+    ],
+
+    shared_libs: [
+        "libvsomeip",
+        "libvsomeip_cfg",
+        "libvsomeip_e2e",
+        "libvsomeip_sd",
+    ],
+}
+
+cc_binary {
+    name: "vsomeip_hello_world_service",
+    defaults: ["vsomeip_hello_world_defaults"],
+
+    srcs: [
+        "hello_world_service.cpp",
+    ],
+}
+
+cc_binary {
+    name: "vsomeip_hello_world_client",
+    defaults: ["vsomeip_hello_world_defaults"],
+
+    srcs: [
+        "hello_world_client.cpp",
+    ],
+}
+
+prebuilt_etc {
+    name: "helloworld-local.json",
+    sub_dir: "vsomeip",
+    src: "helloworld-local.json",
+}

--- a/examples/hello_world/readme
+++ b/examples/hello_world/readme
@@ -6,9 +6,20 @@
 Build instructions for Hello World example
 ------------------------------------------
 
+1. Build whole project at first:
+________________________________
+
+cd <some_path_to_project>/vsomeip$:
 mkdir build
 cd build
 cmake ..
+make
+sudo make install
+
+2. Build hello_world target
+___________________________
+cmake --build . --target hello_world
+cd ./examples/hello_world/
 make
 
 Running Hello World Example

--- a/examples/hello_world/readme-android
+++ b/examples/hello_world/readme-android
@@ -1,0 +1,11 @@
+To start service and client:
+
+Shell1:
+VSOMEIP_CONFIGURATION=/etc/vsomeip/helloworld-local.json \
+VSOMEIP_APPLICATION_NAME=hello_world_service \
+vsomeip_hello_world_service
+
+Shell2:
+VSOMEIP_CONFIGURATION=/etc/vsomeip/helloworld-local.json \
+VSOMEIP_APPLICATION_NAME=hello_world_client \
+vsomeip_hello_world_client

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -26,7 +26,7 @@
 #define VSOMEIP_DEBUG_CONFIGURATION_FOLDER      "/var/opt/public/sin/vsomeip/"
 #define VSOMEIP_LOCAL_CONFIGURATION_FOLDER      "./vsomeip"
 
-#define VSOMEIP_BASE_PATH                       "/storage/"
+#define VSOMEIP_BASE_PATH                       "/data/vendor/vsomeip/"
 
 #define VSOMEIP_CFG_LIBRARY                     "libvsomeip_cfg.so"
 

--- a/implementation/helper/1.66/boost/asio/detail/reactor_op_ext_local.hpp
+++ b/implementation/helper/1.66/boost/asio/detail/reactor_op_ext_local.hpp
@@ -42,6 +42,4 @@ public:
 } // namespace asio
 } // namespace boost
 
-#include <boost/asio/detail/pop_options.hpp>
-
 #endif // BOOST_ASIO_DETAIL_REACTOR_OP_EXT_LOCAL_HPP

--- a/implementation/helper/1.70/boost/asio/detail/reactive_socket_recvfrom_op_ext_local.hpp
+++ b/implementation/helper/1.70/boost/asio/detail/reactive_socket_recvfrom_op_ext_local.hpp
@@ -37,7 +37,7 @@ public:
   reactive_socket_recvfrom_op_base_ext_local(socket_type socket, int protocol_type,
       const MutableBufferSequence& buffers, Endpoint& endpoint,
       socket_base::message_flags flags, func_type complete_func)
-    : reactor_op(&reactive_socket_recvfrom_op_base_ext_local::do_perform, complete_func),
+    : reactor_op_ext_local(&reactive_socket_recvfrom_op_base_ext_local::do_perform, complete_func),
       socket_(socket),
       protocol_type_(protocol_type),
       buffers_(buffers),


### PR DESCRIPTION
Wrong initialization of the base class which leads to compile error:
    
type 'boost::asio::detail::reactor_op' is not a direct or virtual base of 'reactive_socket_recvfrom_op_base_ext_local<MutableBufferSequence, Endpoint>

Tested on AndroidStudio compiler.
