### PR TITLE
Get base path from environment variable for Android NDK

### DIFF
--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -17,6 +17,7 @@
 #define VSOMEIP_ENV_MANDATORY_CONFIGURATION_FILES "VSOMEIP_MANDATORY_CONFIGURATION_FILES"
 #define VSOMEIP_ENV_LOAD_PLUGINS                "VSOMEIP_LOAD_PLUGINS"
 #define VSOMEIP_ENV_CLIENTSIDELOGGING           "VSOMEIP_CLIENTSIDELOGGING"
+#define VSOMEIP_ENV_BASE_PATH                   "VSOMEIP_BASE_PATH"
 
 #define VSOMEIP_DEFAULT_CONFIGURATION_FILE      "/etc/vsomeip.json"
 #define VSOMEIP_LOCAL_CONFIGURATION_FILE        "./vsomeip.json"
@@ -28,11 +29,11 @@
 
 #define VSOMEIP_BASE_PATH                       "/storage/"
 
-#define VSOMEIP_CFG_LIBRARY                     "libvsomeip_cfg.so"
+#define VSOMEIP_CFG_LIBRARY                     "libvsomeip3-cfg.so"
 
-#define VSOMEIP_SD_LIBRARY                      "libvsomeip_sd.so"
+#define VSOMEIP_SD_LIBRARY                      "libvsomeip3-sd.so"
 
-#define VSOMEIP_E2E_LIBRARY                     "libvsomeip-e2e.so.3"
+#define VSOMEIP_E2E_LIBRARY                     "libvsomeip3-e2e.so"
 
 #define VSOMEIP_ROUTING_CLIENT                  0
 

--- a/implementation/utility/src/utility.cpp
+++ b/implementation/utility/src/utility.cpp
@@ -87,6 +87,12 @@ bool utility::is_routing_manager(const std::shared_ptr<configuration> &_config) 
     return (lock_handle__ != INVALID_HANDLE_VALUE);
 #else
     std::string its_base_path(VSOMEIP_BASE_PATH + _config->get_network());
+#ifdef __ANDROID__ // NDK
+    const char *env_base_path = getenv(VSOMEIP_ENV_BASE_PATH);
+    if (nullptr != env_base_path) {
+        its_base_path = {env_base_path + _config->get_network()};
+    }
+#endif
     std::string its_lockfile(its_base_path + ".lck");
     int its_lock_ctrl(-1);
 
@@ -133,6 +139,12 @@ void utility::remove_lockfile(const std::shared_ptr<configuration> &_config) {
     }
 #else
     std::string its_base_path(VSOMEIP_BASE_PATH + _config->get_network());
+#ifdef __ANDROID__ // NDK
+    const char *env_base_path = getenv(VSOMEIP_ENV_BASE_PATH);
+    if (nullptr != env_base_path) {
+        its_base_path = {env_base_path + _config->get_network()};
+    }
+#endif
     std::string its_lockfile(its_base_path + ".lck");
 
     if (lock_fd__ != -1) {
@@ -174,7 +186,17 @@ bool utility::is_folder(const std::string &_path) {
 
 const std::string utility::get_base_path(
         const std::shared_ptr<configuration> &_config) {
+#ifdef __ANDROID__ // NDK
+    const char *env_base_path = getenv(VSOMEIP_ENV_BASE_PATH);
+    if (nullptr != env_base_path) {
+        std::string its_base_path(env_base_path + _config->get_network());
+        return std::string(env_base_path + _config->get_network() + "-");
+    } else {
+        return std::string(VSOMEIP_BASE_PATH + _config->get_network() + "-");
+    }
+#else
     return std::string(VSOMEIP_BASE_PATH + _config->get_network() + "-");
+#endif
 }
 
 client_t


### PR DESCRIPTION
Due to Android restrictions, base path should be defined
in runtime from app local storage.

In addition libraries wrong naming was fixed as well.

Signed-off-by: Nikolay Khilyuk <nkh@ua.fm>