### PR TITLE
Adapt build and hello_world example to Android NDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,17 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(OS_CXX_FLAGS "-D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -fPIE -pie -Wl,-z,relro,-z,now")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Android")
+    set(OS "ANDROID")
+    set(DL_LIBRARY "")
+    set(EXPORTSYMBOLS "")
+    set(NO_DEPRECATED "")
+    set(OPTIMIZE "")
+
+    find_library(ANDROID_LOG_LIB log)
+    set(OS_LIBS ${ANDROID_LOG_LIB})
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     set(OS "FREEBSD")
     set(DL_LIBRARY "")
@@ -132,7 +143,13 @@ endif ()
 find_package(Threads REQUIRED)
 
 # Boost
-find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
+if (${CMAKE_SYSTEM_NAME} MATCHES "Android")
+  # Please implement your macro workaround to set Boost_ variables, because NDK does not have Boost libs package
+  # Example of macro implementation you can find in test project that mentioned in examples/hello_world/readme_android
+  ndk_find_package_boost(system thread filesystem)
+else()
+  find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
+endif()
 include_directories( ${Boost_INCLUDE_DIR} )
 
 if(Boost_FOUND)
@@ -179,9 +196,11 @@ endif()
 # SystemD
 pkg_check_modules(SystemD "libsystemd")
 
-if(NOT SystemD_FOUND)
+if(NOT SystemD_FOUND OR ${CMAKE_SYSTEM_NAME} MATCHES "Android")
 MESSAGE( STATUS "Systemd was not found, watchdog disabled!")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITHOUT_SYSTEMD")
+else()
+list(APPEND OS_LIBS ${SystemD_LIBRARIES})
 endif(NOT SystemD_FOUND)
 
 # Multiple routing managers
@@ -221,7 +240,9 @@ if (MSVC)
     ADD_DEFINITIONS( -DBOOST_ALL_DYN_LINK )
 else()
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${OS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} -std=c++11 ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
-    set(USE_RT "rt")
+    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
+        set(USE_RT "rt")
+    endif()
 endif()
 
 ################################################################################
@@ -238,7 +259,7 @@ if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
         set_target_properties(${VSOMEIP_NAME}-cfg PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
     endif()
 
-    target_link_libraries(${VSOMEIP_NAME}-cfg ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
+    target_link_libraries(${VSOMEIP_NAME}-cfg ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${OS_LIBS})
 endif ()
 
 ################################################################################
@@ -274,7 +295,7 @@ target_include_directories(${VSOMEIP_NAME} INTERFACE
 # them (which shouldn't be required). ${Boost_LIBRARIES} includes absolute
 # build host paths as of writing, which also makes this important as it breaks
 # the build.
-target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OS_LIBS})
 
 ################################################################################
 # Service Discovery library
@@ -290,7 +311,7 @@ if (MSVC)
     set_target_properties(${VSOMEIP_NAME}-sd PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
 endif ()
 
-target_link_libraries(${VSOMEIP_NAME}-sd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${VSOMEIP_NAME}-sd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${OS_LIBS})
 
 
 ################################################################################
@@ -307,7 +328,7 @@ if (MSVC)
     set_target_properties(${VSOMEIP_NAME}-e2e PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
 endif ()
 
-target_link_libraries(${VSOMEIP_NAME}-e2e ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
+target_link_libraries(${VSOMEIP_NAME}-e2e ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${OS_LIBS})
 
 ################################################################################
 # Compatibility library
@@ -338,7 +359,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # for generated files in build mode
     $<INSTALL_INTERFACE:include/compat> # for clients in install mode
 )
-target_link_libraries(${VSOMEIP_COMPAT_NAME} PRIVATE ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
+target_link_libraries(${VSOMEIP_COMPAT_NAME} PRIVATE ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${OS_LIBS})
 
 endif ()
 
@@ -568,21 +589,23 @@ if(NOT WIN32)
 endif()
 
 ##############################################################################
-# build routing manager daemon (Non-Windows only)
-if (NOT MSVC)
-add_subdirectory( examples/routingmanagerd )
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
+    # build routing manager daemon (Non-Windows only)
+    if (NOT MSVC)
+    add_subdirectory( examples/routingmanagerd )
+    endif()
+
+    # build tools
+    add_custom_target( tools )
+    add_subdirectory( tools )
+
+    # build examples
+    add_custom_target( examples )
+    add_subdirectory( examples EXCLUDE_FROM_ALL )
+    add_custom_target( hello_world )
+    add_subdirectory( examples/hello_world  EXCLUDE_FROM_ALL )
 endif()
 
-# build tools
-add_custom_target( tools )
-add_subdirectory( tools )
-
-# build examples
-add_custom_target( examples )
-add_subdirectory( examples EXCLUDE_FROM_ALL )
-add_custom_target( hello_world )
-add_subdirectory( examples/hello_world  EXCLUDE_FROM_ALL )
- 
 ##############################################################################
 # Test section
 ##############################################################################

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -6,22 +6,40 @@
 cmake_minimum_required (VERSION 2.8.7)
 project (vSomeIPHelloWorld)
 
-# This will get us acces to
-#   VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP
-#   VSOMEIP_LIBRARIES    - libraries to link against
-find_package(${VSOMEIP_NAME})
-if (NOT ${VSOMEIP_NAME}_FOUND)
-    message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
-endif()
-
 find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 include_directories(${VSOMEIP_INCLUDE_DIRS})
 
-add_executable (hello_world_service hello_world_service.cpp)
-target_link_libraries(hello_world_service ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_library(vsomeip_hello_world_service INTERFACE)
+target_sources(vsomeip_hello_world_service INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_service.hpp"
+)
+target_include_directories(vsomeip_hello_world_service INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
-add_executable (hello_world_client hello_world_client.cpp)
-target_link_libraries(hello_world_client ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_library(vsomeip_hello_world_client INTERFACE)
+target_sources(vsomeip_hello_world_client INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_client.hpp"
+)
+target_include_directories(vsomeip_hello_world_client INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
+    # This will get us acces to
+    #   VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP
+    #   VSOMEIP_LIBRARIES    - libraries to link against
+    find_package(${VSOMEIP_NAME})
+    if (NOT ${VSOMEIP_NAME}_FOUND)
+        message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
+    endif()
+
+    add_executable (hello_world_service hello_world_service_main.cpp)
+    target_link_libraries(hello_world_service vsomeip_hello_world_service ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+    add_executable (hello_world_client hello_world_client_main.cpp)
+    target_link_libraries(hello_world_client vsomeip_hello_world_client ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/examples/hello_world/hello_world_client_main.cpp
+++ b/examples/hello_world/hello_world_client_main.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+#include <csignal>
+#endif
+#include <vsomeip/vsomeip.hpp>
+#include "hello_world_client.hpp"
+
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+hello_world_client *hw_cl_ptr(nullptr);
+    void handle_signal(int _signal) {
+        if (hw_cl_ptr != nullptr &&
+                (_signal == SIGINT || _signal == SIGTERM))
+            hw_cl_ptr->stop();
+    }
+#endif
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    hello_world_client hw_cl;
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+    hw_cl_ptr = &hw_cl;
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+#endif
+    if (hw_cl.init()) {
+        hw_cl.start();
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/examples/hello_world/hello_world_service_main.cpp
+++ b/examples/hello_world/hello_world_service_main.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+#include <csignal>
+#endif
+#include <vsomeip/vsomeip.hpp>
+#include "hello_world_service.hpp"
+
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+hello_world_service *hw_srv_ptr(nullptr);
+    void handle_signal(int _signal) {
+        if (hw_srv_ptr != nullptr &&
+                (_signal == SIGINT || _signal == SIGTERM))
+            hw_srv_ptr->terminate();
+    }
+#endif
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    hello_world_service hw_srv;
+#ifndef VSOMEIP_ENABLE_SIGNAL_HANDLING
+    hw_srv_ptr = &hw_srv;
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+#endif
+    if (hw_srv.init()) {
+        hw_srv.start();
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/examples/hello_world/readme_android
+++ b/examples/hello_world/readme_android
@@ -1,4 +1,7 @@
-To start service and client:
+AOSP:
+1. Apply vsomeip project to AOSP tree and build hello_world example (e.g. via mma build command)
+2. Push changes to target
+3. Start service and client via different adb shell sessions:
 
 Shell1:
 VSOMEIP_CONFIGURATION=/etc/vsomeip/helloworld-local.json \
@@ -9,3 +12,11 @@ Shell2:
 VSOMEIP_CONFIGURATION=/etc/vsomeip/helloworld-local.json \
 VSOMEIP_APPLICATION_NAME=hello_world_client \
 vsomeip_hello_world_client
+
+NDK:
+AndroidStudio example how to use vsomeip like communication mechanism between two Android services:
+https://github.com/nkh-lab/ndk-vsomeip-hello-world
+
+Expected Android app Logcat output:
+2020-06-05 11:13:06.407 31221-31266/com.example.vsomeiphelloworld I/hello_world_client: Sending: World
+2020-06-05 11:13:06.437 31221-31266/com.example.vsomeiphelloworld I/hello_world_client: Received: Hello World

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -205,6 +205,13 @@ const std::uint32_t ANY_GID = 0xFFFFFFFF;
 
 typedef std::pair<std::uint32_t, std::uint32_t> credentials_t;
 
+enum class port_type_e {
+    PT_OPTIONAL,
+    PT_SECURE,
+    PT_UNSECURE,
+    PT_UNKNOWN
+};
+
 } // namespace vsomeip_v3
 
 #endif // VSOMEIP_V3_INTERNAL_HPP_

--- a/implementation/endpoints/include/tp.hpp
+++ b/implementation/endpoints/include/tp.hpp
@@ -51,7 +51,7 @@ public:
     static tp_split_messages_t tp_split_message(
             const std::uint8_t * const _data, std::uint32_t _size);
 
-    static const std::uint16_t tp_max_segment_length_ = 1392;
+    static const std::uint16_t tp_max_segment_length_;
 };
 
 } // namespace tp

--- a/implementation/endpoints/src/tp.cpp
+++ b/implementation/endpoints/src/tp.cpp
@@ -26,6 +26,8 @@
 namespace vsomeip_v3 {
 namespace tp {
 
+const std::uint16_t tp::tp_max_segment_length_ = 1392;
+
 tp_split_messages_t tp::tp_split_message(const std::uint8_t * const _data,
                                          std::uint32_t _size) {
     tp_split_messages_t split_messages;

--- a/implementation/logger/src/message.cpp
+++ b/implementation/logger/src/message.cpp
@@ -10,7 +10,11 @@
 #include <iostream>
 
 #ifdef ANDROID
-#include <utils/Log.h>
+#include <android/log.h>
+
+#ifndef LOG_TAG
+#define LOG_TAG NULL
+#endif
 #endif
 
 #include <vsomeip/internal/logger.hpp>
@@ -90,25 +94,25 @@ message::~message() {
 #else
             switch (level_) {
             case level_e::LL_FATAL:
-                ALOGE(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             case level_e::LL_ERROR:
-                ALOGE(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             case level_e::LL_WARNING:
-                ALOGW(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_WARN, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             case level_e::LL_INFO:
-                ALOGI(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_INFO, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             case level_e::LL_DEBUG:
-                ALOGD(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             case level_e::LL_VERBOSE:
-                ALOGV(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, "%s", buffer_.data_.str().c_str());
                 break;
             default:
-                ALOGI(buffer_.data_.str());
+                (void)__android_log_print(ANDROID_LOG_INFO, LOG_TAG, "%s", buffer_.data_.str().c_str());
             };
 #endif // !ANDROID
         }


### PR DESCRIPTION
Build adaptations and fixes:
- adapt root CMakeLists.txt to Android NDK build
- add missed port_type_e in internal_android.hpp
- move tp_max_segment_length_ from tp.hpp to tp.cpp due to linker error
- rework message.cpp logging, using <android/log.h> instead of <utils/Log.h> to support both AOSP and NDK builds

examples/hello_world adaptation:
- rework structure to have possibility to build examples like independent executables or
  like header libraries for usage them from client code (e.g. from native part of Android app services)
- update readme_android with NDK usage example

Signed-off-by: Nikolay Khilyuk <nkh@ua.fm>