### PR TITLE
.bugfix for cmake install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@ endif()
 ###################################################################################################
 
 # Offer the user the choice of overriding the installation directories
-set (INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
-set (INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
-set (INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
+set (INSTALL_LIB_DIR lib CACHE STRING "Installation directory for libraries")
+set (INSTALL_BIN_DIR bin CACHE STRING "Installation directory for executables")
+set (INSTALL_INCLUDE_DIR include CACHE STRING "Installation directory for header files")
 
 if (WIN32 AND NOT CYGWIN)
     set (DEF_INSTALL_CMAKE_DIR CMake)
@@ -41,15 +41,7 @@ else ()
     set (DEF_INSTALL_CMAKE_DIR lib/cmake/${VSOMEIP_NAME})
 endif ()
 
-set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
-
-# Make relative paths absolute (needed later on)
-foreach (p LIB BIN INCLUDE CMAKE)
-    set (var INSTALL_${p}_DIR)
-    if (NOT IS_ABSOLUTE "${${var}}")
-        set (ABSOLUTE_${var} "${CMAKE_INSTALL_PREFIX}/${${var}}") # Add all targets to the build-tree export set
-    endif ()
-endforeach ()
+set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE STRING "Installation directory for CMake files")
 
 ###################################################################################################
 # Set a default build type if none was specified


### PR DESCRIPTION
 shall be always relative to cmake-install-prefix

fix for #150