### PR TITLE
Fix application not calling availability handlers when router goes down

### DIFF
--- a/implementation/runtime/include/application_impl.hpp
+++ b/implementation/runtime/include/application_impl.hpp
@@ -347,7 +347,7 @@ private:
     typedef std::map<major_version_t, std::map<minor_version_t, std::pair<availability_handler_t,
             bool>>> availability_major_minor_t;
     std::map<service_t, std::map<instance_t, availability_major_minor_t>> availability_;
-    mutable std::mutex availability_mutex_;
+    mutable std::recursive_mutex availability_mutex_;
 
     // Availability
     mutable available_t available_;


### PR DESCRIPTION
In the event of router manager crashing, the application will not update
the map of available services accordingly. As the router is down, the map
of available services should be cleared to reflect this state.

When the router manager is restarted, the application will still have the
old state of services, causing the router manager and application to be
out of sync.

This patch fixes the above issues by clearing the map of available services
and notifying clients by calling the availability handler.