### PR TITLE
Bug-Fixes regarding IPv6 Multicast and Multicast Endpoint Clean-up

### DIFF
--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -439,7 +439,11 @@ void endpoint_manager_impl::clear_multicast_endpoints(service_t _service, instan
                     multicast_info.erase(_service);
                 }
                 // Clear service_instances_ for multicast endpoint
-                (void)remove_instance(_service, multicast_endpoint.get());
+                if (multicast_endpoint) {
+                    (void)remove_instance(_service, multicast_endpoint.get());
+                } else {
+                    VSOMEIP_ERROR << "Invalid multicast endpoint, not able to remove services";
+                }
             }
         }
     }

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -363,12 +363,26 @@ void udp_server_endpoint_impl::join(const std::string &_address) {
 
 #ifdef _WIN32
                 const char* optval("0001");
-                ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IP, IP_PKTINFO,
-                    optval, sizeof(optval));
+                if (is_v4) {
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IP, IP_PKTINFO,
+                        optval, sizeof(optval));
+                } else if (is_v6) {
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IPV6, IPV6_PKTINFO,
+                        optval, sizeof(optval));
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IPV6, IPV6_RECVPKTINFO,
+                        &optval, sizeof(optval));
+                }
 #else
                 int optval(1);
-                ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IP, IP_PKTINFO,
-                    &optval, sizeof(optval));
+                if (is_v4) {
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IP, IP_PKTINFO,
+                        &optval, sizeof(optval));
+                } else if (is_v6) {
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IPV6, IPV6_PKTINFO,
+                        &optval, sizeof(optval));
+                    ::setsockopt(multicast_socket_->native_handle(), IPPROTO_IPV6, IPV6_RECVPKTINFO,
+                        &optval, sizeof(optval));
+                }
 #endif
                 multicast_id_++;
                 receive_multicast(multicast_id_);

--- a/implementation/helper/1.70/boost/asio/detail/impl/socket_ops_ext.ipp
+++ b/implementation/helper/1.70/boost/asio/detail/impl/socket_ops_ext.ipp
@@ -64,14 +64,25 @@ signed_size_type recvfrom(socket_type s, buf* bufs, size_t count,
          cmsg != NULL;
          cmsg = WSA_CMSG_NXTHDR(&msg, cmsg))
     {
-      if (cmsg->cmsg_level != IPPROTO_IP || cmsg->cmsg_type != IP_PKTINFO)
-        continue;
-
-      struct in_pktinfo *pi = (struct in_pktinfo *) WSA_CMSG_DATA(cmsg);
-      if (pi)
+      if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO))
       {
-        da = boost::asio::ip::address_v4(ntohl(pi->ipi_addr.s_addr));
-      } 
+        struct in_pktinfo *pi = (struct in_pktinfo *) WSA_CMSG_DATA(cmsg);
+        if (pi)
+        {
+          da = boost::asio::ip::address_v4(ntohl(pi->ipi_addr.s_addr));
+        }
+      }
+
+      if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO))
+      {
+        struct in6_pktinfo *pi = (struct in6_pktinfo *) WSA_CMSG_DATA(cmsg);
+        if (pi)
+        {
+          boost::asio::ip::address_v6::bytes_type v6_buf;
+          memcpy(v6_buf.data(), pi->ipi6_addr.s6_addr, sizeof(pi->ipi6_addr.u.Byte));
+          da = boost::asio::ip::address_v6(v6_buf);
+        }
+      }
     }      
   } else {
     dwNumberOfBytesRecvd = -1;
@@ -96,14 +107,25 @@ signed_size_type recvfrom(socket_type s, buf* bufs, size_t count,
          cmsg != NULL;
          cmsg = CMSG_NXTHDR(&msg, cmsg))
     {
-      if (cmsg->cmsg_level != IPPROTO_IP || cmsg->cmsg_type != IP_PKTINFO)
-        continue;
-
-      struct in_pktinfo *pi = (struct in_pktinfo *) CMSG_DATA(cmsg);
-      if (pi)
+      if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO))
       {
-        da = boost::asio::ip::address_v4(ntohl(pi->ipi_addr.s_addr));
-      } 
+        struct in_pktinfo *pi = (struct in_pktinfo *) CMSG_DATA(cmsg);
+        if (pi)
+        {
+          da = boost::asio::ip::address_v4(ntohl(pi->ipi_addr.s_addr));
+        }
+      }
+
+      if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO))
+      {
+        struct in6_pktinfo *pi = (struct in6_pktinfo *) CMSG_DATA(cmsg);
+        if (pi)
+        {
+          boost::asio::ip::address_v6::bytes_type v6_buf;
+          memcpy(v6_buf.data(), pi->ipi6_addr.s6_addr, sizeof(pi->ipi6_addr.s6_addr));
+          da = boost::asio::ip::address_v6(v6_buf);
+        }
+      }
     }
   }
   return result;


### PR DESCRIPTION
So far, there was no handling implemented to retrieve the destination address from IPv6 multicast messages.

Further, there was a possible nullpointer exception at the multicast endpoint clean-up.