### PR TITLE
Remove ndk_find_package_boost() Android custom macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,13 +140,7 @@ endif ()
 find_package(Threads REQUIRED)
 
 # Boost
-if (${CMAKE_SYSTEM_NAME} MATCHES "Android")
-  # Please implement your macro workaround to set Boost_ variables, because NDK does not have Boost libs package
-  # Example of macro implementation you can find in test project that mentioned in examples/hello_world/readme_android
-  ndk_find_package_boost(system thread filesystem)
-else()
-  find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
-endif()
+find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
 include_directories( ${Boost_INCLUDE_DIR} )
 
 if(Boost_FOUND)


### PR DESCRIPTION
Instead of custom ndk_find_package_boost() macro, should be used cmake true approach to support
find_package(), e.g. via providing FindBoost.cmake.

An example of how FindBoost.cmake might look:
https://github.com/nkh-lab/ndk-vsomeip-hello-world/blob/delete_ndk_find_package_boost/cmake/FindBoost.cmake

Signed-off-by: Nikolay Khilyuk <nkh@ua.fm>